### PR TITLE
Allow passing a client directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ import { ThrottlerStorageRedisService } from 'nestjs-throttler-storage-redis';
     ThrottlerModule.forRoot({
       ttl: 60,
       limit: 5,
-      storage: new ThrottlerStorageRedisService(),
+      storage: new ThrottlerStorageRedisService(<Redis.Redis>client),
+      // storage: ThrottlerStorageRedisService.create(),
+      // storage: ThrottlerStorageRedisService.create(<Redis.RedisOptions>options),
     }),
   ],
 })

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Redis storage provider for the [nestjs-throttler](nestjs-throttler) package.
 
 ```ts
 import { ThrottlerModule } from 'nestjs-throttler';
+import * as Redis from 'ioredis';
 import { ThrottlerStorageRedisService } from 'nestjs-throttler-storage-redis';
 
 @Module({
@@ -42,7 +43,9 @@ import { ThrottlerStorageRedisService } from 'nestjs-throttler-storage-redis';
       useFactory: (config: ConfigService) => ({
         ttl: config.get('THROTTLE_TTL'),
         limit: config.get('THROTTLE_LIMIT'),
-        storage: new ThrottlerStorageRedisService(),
+        storage: new ThrottlerStorageRedisService(<Redis.Redis>client),
+        // storage: ThrottlerStorageRedisService.create(),
+        // storage: ThrottlerStorageRedisService.create(<Redis.RedisOptions>options),
       }),
     }),
   ],

--- a/src/throttler-storage-redis.service.ts
+++ b/src/throttler-storage-redis.service.ts
@@ -4,11 +4,7 @@ import { ThrottlerStorageRedis } from './throttler-storage-redis.interface';
 
 @Injectable()
 export class ThrottlerStorageRedisService implements ThrottlerStorageRedis {
-  redis: Redis.Redis;
-
-  constructor(options?: Redis.RedisOptions) {
-    this.redis = new Redis(options);
-  }
+  constructor(private redis: Redis.Redis) {}
 
   async getRecord(key: string): Promise<number[]> {
     const ttls = (await this.redis.scan(0, 'MATCH', `${key}:*`)).pop();
@@ -17,5 +13,9 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis {
 
   async addRecord(key: string, ttl: number): Promise<void> {
     this.redis.set(`${key}:${Date.now() + ttl * 1000}`, ttl, 'EX', ttl);
+  }
+  
+  static create(options?: Redis.RedisOptions) {
+    return new this(new Redis(options));
   }
 }


### PR DESCRIPTION
In order to avoid client duplications- allow passing a ioredis client instance directly to the service.