### PR TITLE
fix: disconnect redis to avoid open handles

### DIFF
--- a/src/throttler-storage-redis.service.ts
+++ b/src/throttler-storage-redis.service.ts
@@ -1,10 +1,11 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import * as Redis from 'ioredis';
 import { ThrottlerStorageRedis } from './throttler-storage-redis.interface';
 
 @Injectable()
-export class ThrottlerStorageRedisService implements ThrottlerStorageRedis {
+export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnModuleDestroy {
   redis: Redis.Redis;
+  disconnectRequired?: boolean;
   scanCount: number;
 
   constructor(redis?: Redis.Redis, scanCount?: number);
@@ -17,8 +18,10 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis {
       this.redis = redisOrOptions;
     } else if (typeof redisOrOptions === 'string') {
       this.redis = new Redis(redisOrOptions as string);
+      this.disconnectRequired = true;
     } else {
       this.redis = new Redis(redisOrOptions);
+      this.disconnectRequired = true;
     }
   }
 
@@ -29,5 +32,11 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis {
 
   async addRecord(key: string, ttl: number): Promise<void> {
     await this.redis.set(`${key}:${Date.now() + ttl * 1000}`, ttl, 'EX', ttl);
+  }
+
+  onModuleDestroy() {
+    if (this.disconnectRequired) {
+      this.redis?.disconnect(false);
+    }
   }
 }


### PR DESCRIPTION
Client application doing e2e tests with nestjs-throttler-storage-redis can leads to open handles error when using a configuration instead of ioredis instance.
Example: `storage: new ThrottlerStorageRedisService(redisConfig)`

```
at node_modules/ioredis/built/redis/index.js:268:48
      at Redis.Object.<anonymous>.Redis.connect (node_modules/ioredis/built/redis/index.js:258:21)
      at new Redis (node_modules/ioredis/built/redis/index.js:167:14)
      at new ThrottlerStorageRedisService (node_modules/nestjs-throttler-storage-redis/src/throttler-storage-redis.service.ts:21:20)
```