### PR TITLE
chore: adding reflect-metadata version 1 as a compatible peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "@nestjs/throttler": ">=6.0.0",
     "ioredis": ">=5.0.0",
-    "reflect-metadata": "^0.2.1"
+    "reflect-metadata": "^0.1.13 || ^0.2.0"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
The @nestjs/throttler version 6 supports both reflect-metadata version 1 and 2, as well as nestjs 9 and 10

However version 5 of this library removed reflect-metadata v1 which causes npm to break on installs nestjs installs older than 10