### PR TITLE
Update throttler-storage-redis.service.ts

### DIFF
--- a/src/throttler-storage-redis.service.ts
+++ b/src/throttler-storage-redis.service.ts
@@ -8,7 +8,8 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
   scriptSrc: string;
   redis: Redis | Cluster;
   disconnectRequired?: boolean;
-
+  private keySeparator: string = '-';
+  
   constructor(redis?: Redis);
   constructor(cluster?: Cluster);
   constructor(options?: RedisOptions);
@@ -130,7 +131,11 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
       timeToBlockExpire: Math.ceil(timeToBlockExpire / 1000),
     };
   }
-
+  
+  setKeySeparator(separator: string) {
+     this.keySeparator = separator;
+  }
+  
   onModuleDestroy() {
     if (this.disconnectRequired) {
       this.redis?.disconnect(false);

--- a/src/throttler-storage-redis.service.ts
+++ b/src/throttler-storage-redis.service.ts
@@ -78,8 +78,17 @@ export class ThrottlerStorageRedisService implements ThrottlerStorageRedis, OnMo
     blockDuration: number,
     throttlerName: string,
   ): Promise<ThrottlerStorageRecord> {
-    const hitKey = `${this.redis.options.keyPrefix}{${key}:${throttlerName}}:hits`;
-    const blockKey = `${this.redis.options.keyPrefix}{${key}:${throttlerName}}:blocked`;
+    
+    let hitKey = this.redis.options.keyPrefix;
+    let blockKey = this.redis.options.keyPrefix;  
+    
+    if (hitKey !== undefined && hitKey !== null && hitKey != ''){
+        hitKey += this.keySeparator;
+        blockKey += this.keySeparator;
+    }
+    hitKey += `${key}:${throttlerName}:hits`;
+    blockKey += `${key}:${throttlerName}:blocked`;
+    
     const results: number[] = (await this.redis.call(
       'EVAL',
       this.scriptSrc,


### PR DESCRIPTION
Add  `key separator` for throttler. existing  `{` one make harder to clear ratelimiter keys in redis through pattern search.

And it will introduced feature to setup user defined key separator.

Please help @kkoomen .